### PR TITLE
Some improvements to the table-aliases

### DIFF
--- a/1_modified_core_files/YOUR_ADMIN/geo_zones.php
+++ b/1_modified_core_files/YOUR_ADMIN/geo_zones.php
@@ -211,13 +211,13 @@ function update_zone(theForm) {
 // reset page when page is unknown
 if ((!isset($_GET['spage']) or $_GET['spage'] == '' or $_GET['spage'] == '1') and $_GET['sID'] != '') {
 // BOF Zen4All Multi Language Country Names 1 of 2
-  $zones_query_raw = "SELECT a.association_id, a.zone_country_id, c.countries_name, a.zone_id, a.geo_zone_id, a.last_modified, a.date_added, z.zone_name
+  $zones_query_raw = "SELECT a.association_id, a.zone_country_id, cn.countries_name, a.zone_id, a.geo_zone_id, a.last_modified, a.date_added, z.zone_name
                       FROM (" . TABLE_ZONES_TO_GEO_ZONES . " a
-                      LEFT JOIN " . TABLE_COUNTRIES_NAME . " c ON a.zone_country_id = c.countries_id
+                      LEFT JOIN " . TABLE_COUNTRIES_NAME . " cn ON a.zone_country_id = cn.countries_id
                       LEFT JOIN " . TABLE_ZONES . " z ON a.zone_id = z.zone_id)
                       WHERE a.geo_zone_id = " . (int)$_GET['zID'] . "
-                      AND c.language_id = '" . (int)$_SESSION['languages_id'] . "'
-                      ORDER BY c.countries_name, association_id";
+                      AND cn.language_id = '" . (int)$_SESSION['languages_id'] . "'
+                      ORDER BY cn.countries_name, association_id";
 // EOF Zen4All Multi Language Country Names 1 of 2
   $check_page = $db->Execute($zones_query_raw);
   $check_count=1;
@@ -236,13 +236,13 @@ if ((!isset($_GET['spage']) or $_GET['spage'] == '' or $_GET['spage'] == '1') an
 }
     $rows = 0;
 // BOF Zen4All Multi Language Country Names 2 of 2
-    $zones_query_raw = "SELECT a.association_id, a.zone_country_id, c.countries_name, a.zone_id, a.geo_zone_id, a.last_modified, a.date_added, z.zone_name
+    $zones_query_raw = "SELECT a.association_id, a.zone_country_id, cn.countries_name, a.zone_id, a.geo_zone_id, a.last_modified, a.date_added, z.zone_name
                         FROM (" . TABLE_ZONES_TO_GEO_ZONES . " a
-                        LEFT JOIN " . TABLE_COUNTRIES_NAME . " c ON a.zone_country_id = c.countries_id
+                        LEFT JOIN " . TABLE_COUNTRIES_NAME . " cn ON a.zone_country_id = cn.countries_id
                         LEFT JOIN " . TABLE_ZONES . " z ON a.zone_id = z.zone_id)
                         WHERE a.geo_zone_id = " . (int)$_GET['zID'] . "
-                        AND c.language_id = '" . (int)$_SESSION['languages_id'] . "'
-                        ORDER BY c.countries_name, association_id";
+                        AND cn.language_id = '" . (int)$_SESSION['languages_id'] . "'
+                        ORDER BY cn.countries_name, association_id";
 // EOF Zen4All Multi Language Country Names 2 of 2
     $zones_split = new splitPageResults($_GET['spage'], MAX_DISPLAY_SEARCH_RESULTS, $zones_query_raw, $zones_query_numrows);
     $zones = $db->Execute($zones_query_raw);

--- a/1_modified_core_files/YOUR_ADMIN/linkpoint_review.php
+++ b/1_modified_core_files/YOUR_ADMIN/linkpoint_review.php
@@ -273,7 +273,7 @@ if ($_GET['page'] == '' and $_GET['cID'] != '') {
         $country = $db->Execute("SELECT countries_name
                                  FROM " . TABLE_COUNTRIES_NAME . "
                                  WHERE countries_id = '" . (int)$customers->fields['entry_country_id'] . "'
-                                 AND con.language_id = '" . (int)$_SESSION['languages_id'] . "'");
+                                 AND language_id = '" . (int)$_SESSION['languages_id'] . "'");
 // EOF Zen4All Multi Language Country Names 1 of 1
         if (!is_array($country->fields)) $country->fields = array();
 

--- a/1_modified_core_files/YOUR_ADMIN/zones.php
+++ b/1_modified_core_files/YOUR_ADMIN/zones.php
@@ -108,11 +108,11 @@
                     </tr>
                     <?php
 // BOF Zen4All Multi Language Country Names 1 of 1
-  $zones_query_raw = "SELECT z.zone_id, c.countries_id, c.countries_name, z.zone_name, z.zone_code, z.zone_country_id
-                      FROM " . TABLE_ZONES . " z, " . TABLE_COUNTRIES_NAME . " c
-                      WHERE z.zone_country_id = c.countries_id
+  $zones_query_raw = "SELECT z.zone_id, cn.countries_id, cn.countries_name, z.zone_name, z.zone_code, z.zone_country_id
+                      FROM " . TABLE_ZONES . " z, " . TABLE_COUNTRIES_NAME . " cn
+                      WHERE z.zone_country_id = cn.countries_id
                       AND language_id = '" . (int)$_SESSION['languages_id'] . "'
-                      ORDER BY c.countries_name, z.zone_name";
+                      ORDER BY cn.countries_name, z.zone_name";
 // EOF Zen4All Multi Language Country Names 1 of 1
   $zones_split = new splitPageResults($_GET['page'], MAX_DISPLAY_SEARCH_RESULTS, $zones_query_raw, $zones_query_numrows);
   $zones = $db->Execute($zones_query_raw);

--- a/1_modified_core_files/includes/classes/order.php
+++ b/1_modified_core_files/includes/classes/order.php
@@ -252,17 +252,17 @@ class order extends base {
     $customer_address_query = "select c.customers_firstname, c.customers_lastname, c.customers_telephone,
                                     c.customers_email_address, ab.entry_company, ab.entry_street_address,
                                     ab.entry_suburb, ab.entry_postcode, ab.entry_city, ab.entry_zone_id,
-                                    z.zone_name, co.countries_id, con.countries_name,
+                                    z.zone_name, co.countries_id, cn.countries_name,
                                     co.countries_iso_code_2, co.countries_iso_code_3,
                                     co.address_format_id, ab.entry_state
                                    from (" . TABLE_CUSTOMERS . " c, " . TABLE_ADDRESS_BOOK . " ab )
                                    left join " . TABLE_ZONES . " z on (ab.entry_zone_id = z.zone_id)
                                    left join " . TABLE_COUNTRIES . " co on (ab.entry_country_id = co.countries_id)
-                                   left join " . TABLE_COUNTRIES_NAME . " con on (ab.entry_country_id = con.countries_id)
+                                   left join " . TABLE_COUNTRIES_NAME . " cn on (c.countries_id = cn.countries_id)
                                    where c.customers_id = '" . (int)$_SESSION['customer_id'] . "'
                                    and ab.customers_id = '" . (int)$_SESSION['customer_id'] . "'
                                    and c.customers_default_address_id = ab.address_book_id
-                                   and con.language_id = '" . (int)$_SESSION['languages_id'] . "'";
+                                   and cn.language_id = '" . (int)$_SESSION['languages_id'] . "'";
 // EOF Zen4All Multi Language Country Names 1 of 3
 
     $customer_address = $db->Execute($customer_address_query);
@@ -271,15 +271,15 @@ class order extends base {
     $shipping_address_query = "select ab.entry_firstname, ab.entry_lastname, ab.entry_company,
                                     ab.entry_street_address, ab.entry_suburb, ab.entry_postcode,
                                     ab.entry_city, ab.entry_zone_id, z.zone_name, ab.entry_country_id,
-                                    c.countries_id, con.countries_name, c.countries_iso_code_2,
+                                    c.countries_id, cn.countries_name, c.countries_iso_code_2,
                                     c.countries_iso_code_3, c.address_format_id, ab.entry_state
                                    from " . TABLE_ADDRESS_BOOK . " ab
                                    left join " . TABLE_ZONES . " z on (ab.entry_zone_id = z.zone_id)
                                    left join " . TABLE_COUNTRIES . " c on (ab.entry_country_id = c.countries_id)
-                                   left join " . TABLE_COUNTRIES_NAME . " con on (ab.entry_country_id = con.countries_id)
+                                   left join " . TABLE_COUNTRIES_NAME . " cn on (c.countries_id = cn.countries_id)
                                    where ab.customers_id = '" . (int)$_SESSION['customer_id'] . "'
                                    and ab.address_book_id = '" . (int)$_SESSION['sendto'] . "'
-                                   and con.language_id = '" . (int)$_SESSION['languages_id'] . "'";
+                                   and cn.language_id = '" . (int)$_SESSION['languages_id'] . "'";
 // EOF Zen4All Multi Language Country Names 2 of 3
 
     $shipping_address = $db->Execute($shipping_address_query);
@@ -288,15 +288,15 @@ class order extends base {
     $billing_address_query = "select ab.entry_firstname, ab.entry_lastname, ab.entry_company,
                                    ab.entry_street_address, ab.entry_suburb, ab.entry_postcode,
                                    ab.entry_city, ab.entry_zone_id, z.zone_name, ab.entry_country_id,
-                                   c.countries_id, con.countries_name, c.countries_iso_code_2,
+                                   c.countries_id, cn.countries_name, c.countries_iso_code_2,
                                    c.countries_iso_code_3, c.address_format_id, ab.entry_state
                                   from " . TABLE_ADDRESS_BOOK . " ab
                                   left join " . TABLE_ZONES . " z on (ab.entry_zone_id = z.zone_id)
                                   left join " . TABLE_COUNTRIES . " c on (ab.entry_country_id = c.countries_id)
-                                  left join " . TABLE_COUNTRIES_NAME . " con on (ab.entry_country_id = con.countries_id)
+                                  left join " . TABLE_COUNTRIES_NAME . " cn on (c.countries_id = cn.countries_id)
                                   where ab.customers_id = '" . (int)$_SESSION['customer_id'] . "'
                                   and ab.address_book_id = '" . (int)$_SESSION['billto'] . "'
-                                  and con.language_id = '" . (int)$_SESSION['languages_id'] . "'";
+                                  and cn.language_id = '" . (int)$_SESSION['languages_id'] . "'";
 // EOF Zen4All Multi Language Country Names 3 of 3
 
     $billing_address = $db->Execute($billing_address_query);

--- a/1_modified_core_files/includes/functions/functions_lookups.php
+++ b/1_modified_core_files/includes/functions/functions_lookups.php
@@ -22,13 +22,13 @@
     if (zen_not_null($countries_id)) {
       $countries_array['countries_name'] = '';
 // BOF Zen4All Multi Language Country Names 1 of 2
-      $countries = "SELECT con.countries_name, co.countries_iso_code_2, co.countries_iso_code_3
-                    FROM " . TABLE_COUNTRIES . " co, " . TABLE_COUNTRIES_NAME . " con
+      $countries = "SELECT cn.countries_name, countries_iso_code_2, countries_iso_code_3
+                    FROM " . TABLE_COUNTRIES . " co, " . TABLE_COUNTRIES_NAME . " cn
                     WHERE co.countries_id = '" . (int)$countries_id . "'
-                    AND con.countries_id = co.countries_id
-                    AND con.language_id = '" . (int)$_SESSION['languages_id'] . "'";
+                    AND cn.countries_id = co.countries_id
+                    AND cn.language_id = '" . (int)$_SESSION['languages_id'] . "'";
       if ($activeOnly) $countries .= " AND co.status != 0 ";
-      $countries .= " ORDER BY con.countries_name";
+      $countries .= " ORDER BY cn.countries_name";
 // EOF Zen4All Multi Language Country Names 1 of 2
       $countries_values = $db->Execute($countries);
 
@@ -45,12 +45,12 @@
       }
     } else {
 // BOF Zen4All Multi Language Country Names 2 of 2
-      $countries = "SELECT co.countries_id, con.countries_name
-                    FROM " . TABLE_COUNTRIES . " co, " . TABLE_COUNTRIES_NAME . " con";
+      $countries = "SELECT co.countries_id, cn.countries_name
+                    FROM " . TABLE_COUNTRIES . " co, " . TABLE_COUNTRIES_NAME . " cn";
       if ($activeOnly) $countries .= " WHERE co.status != 0 ";
-      $countries .= " AND con.countries_id = co.countries_id";
-      $countries .= " AND con.language_id = '" . (int)$_SESSION['languages_id'] . "'";
-      $countries .= " ORDER BY con.countries_name";
+      $countries .= " AND cn.countries_id = co.countries_id";
+      $countries .= " AND cn.language_id = '" . (int)$_SESSION['languages_id'] . "'";
+      $countries .= " ORDER BY cn.countries_name";
 // EOF Zen4All Multi Language Country Names 2 of 2
       $countries_values = $db->Execute($countries);
       while (!$countries_values->EOF) {

--- a/1_modified_core_files/includes/modules/payment/paypalwpp.php
+++ b/1_modified_core_files/includes/modules/payment/paypalwpp.php
@@ -1784,10 +1784,10 @@ class paypalwpp extends base {
 
     // Get the customer's country ID based on name or ISO code
 // BOF Zen4All Multi Language Country Names 1 of 3
-    $sql = "SELECT c.countries_id, c.address_format_id, c.countries_iso_code_2, c.countries_iso_code_3
+    $sql = "SELECT c.countries_id, address_format_id, countries_iso_code_2, countries_iso_code_3
                 FROM " . TABLE_COUNTRIES . " c, " . TABLE_COUNTRIES_NAME . " cn
-                WHERE c.countries_iso_code_2 = :countryId
-                   OR cn.countries_name = :countryId
+                WHERE (countries_iso_code_2 = :countryId
+                   OR cn.countries_name = :countryId)
                 AND cn.countries_id = c.countries_id
                 AND cn.language_id = '" . (int)$_SESSION['languages_id'] . "'
                 LIMIT 1";
@@ -2272,12 +2272,12 @@ class paypalwpp extends base {
     // first get the zone id's from the 2 digit iso codes
     // country first
 // BOF Zen4All Multi Language Country Names 2 of 3
-    $sql = "SELECT c.countries_id, c.address_format_id
+    $sql = "SELECT c.countries_id, address_format_id
                 FROM " . TABLE_COUNTRIES . " c, " . TABLE_COUNTRIES_NAME . " cn
-                WHERE c.countries_iso_code_2 = :countryCode:
+                WHERE (countries_iso_code_2 = :countryCode:
                 OR cn.countries_name = :countryName:
-                OR c.countries_iso_code_2 = :countryName:
-                OR cn.countries_name = :countryCode:
+                OR countries_iso_code_2 = :countryName:
+                OR cn.countries_name = :countryCode:)
                 AND cn.countries_id = c.countries_id
                 AND cn.language_id = '" . (int)$_SESSION['languages_id'] . "'
                 LIMIT 1";
@@ -2432,12 +2432,12 @@ class paypalwpp extends base {
     // first get the zone id's from the 2 digit iso codes
     // country first
 // BOF Zen4All Multi Language Country Names 3 of 3
-    $sql = "SELECT c.countries_id, c.address_format_id
+    $sql = "SELECT c.countries_id, address_format_id
                 FROM " . TABLE_COUNTRIES . " c, " . TABLE_COUNTRIES_NAME . " cn
-                WHERE c.countries_iso_code_2 = :countryCode:
-                OR c.countries_name = :countryName:
-                OR c.countries_iso_code_2 = :countryName:
-                OR cn.countries_name = :countryCode:
+                WHERE (countries_iso_code_2 = :countryCode:
+                OR cn.countries_name = :countryName:
+                OR countries_iso_code_2 = :countryName:
+                OR cn.countries_name = :countryCode:)
                 AND cn.countries_id = c.countries_id
                 AND cn.language_id = '" . (int)$_SESSION['languages_id'] . "'
                 LIMIT 1";


### PR DESCRIPTION
Some recommendations for improvement.

This PR:
- changed the various "con." alias to "cn." for consistency
- removed the undeclared "con." alias from the linkpoint file because it was causing an error
- In a few places removed the unnecessary "c." prefixes just to minimize code changes from original core code.
  (ie: the "c." or "cn." prefix only needs to be mentioned when there are other fields of the same name which could create ambiguity, especially in SELECT and ORDER BY clauses. Sometimes it's helpful to mention them anyway just for clarity to the coder, and that's fine.

I also notice that the "countries_name" field in the COUNTRIES table is left intact, which does create some ambiguity about which table contains the master copy of the names. If this were to be considered for core-code then that ambiguity would need to be mitigated, ideally by deleting the column from the COUNTRIES table.
